### PR TITLE
The compare subcommand

### DIFF
--- a/src/blocks/compare/kinds.rs
+++ b/src/blocks/compare/kinds.rs
@@ -1,0 +1,44 @@
+#[derive(Debug)]
+pub enum PropertyComparison {
+    /// The base is equal to the target property -> 100% compatible
+    Equal,
+    /// The base has less elements than the target property -> 100% compatible
+    MissingEnd,
+    /// The base has more elements than the target property -> not compatible
+    LongerEnd,
+    /// The order of the base elements is different from the target property -> 100% compatible
+    DifferentOrdering,
+    /// The values (and maybe ordering) of the base elements is different from the target property -> not compatible
+    DifferentValues,
+}
+
+impl PropertyComparison {
+    pub fn compare<'raw>(base: &Vec<&'raw str>, target: &Vec<&'raw str>) -> Self {
+        if base == target {
+            Self::Equal
+        } else {
+            let mut last_index = 0;
+            for (i, value) in base.iter().enumerate() {
+                if matches!(target.get(i), Some(x) if x == value) {
+                    if last_index != i {
+                        break;
+                    }
+                    last_index += 1;
+                }
+            }
+            if last_index == base.len() {
+                return if target.len() > base.len() {
+                    Self::MissingEnd
+                } else {
+                    Self::LongerEnd
+                }
+            }
+            for value in base {
+                if !target.contains(value) {
+                    return Self::DifferentValues
+                }
+            }
+            Self::DifferentOrdering
+        }
+    }
+}

--- a/src/blocks/compare/mod.rs
+++ b/src/blocks/compare/mod.rs
@@ -1,5 +1,10 @@
+use anyhow::Context;
 use clap::Args;
+use crate::blocks::compare::kinds::PropertyComparison;
+use crate::blocks::intermediary::data::ModernBlockList;
 use crate::util::file::InputFile;
+
+pub mod kinds;
 
 #[derive(Args, Debug)]
 /// Compare two data versions one-directional
@@ -13,8 +18,22 @@ pub struct CompareCommand {
 }
 
 impl CompareCommand {
-    pub fn compare(&self) -> anyhow::Result<()> {
-        eprintln!("Comparing...");
+    pub fn compare<'raw>(&self) -> anyhow::Result<()> {
+        let base_version: ModernBlockList = self.base.data().with_context(|| format!("Error deserializing {:?}", self.base.name()))?;
+        let target_version: ModernBlockList = self.target.data().with_context(|| format!("Error deserializing {:?}", self.target.name()))?;
+
+        eprintln!("Checking property compatibility...");
+        for (property, base) in base_version.properties() {
+            if let Some(target) = target_version.properties().get(property) {
+                match PropertyComparison::compare(base, target) {
+                    PropertyComparison::Equal => {}
+                    cmp => eprintln!("\"{}\" has {:?}", property, cmp),
+                }
+            } else {
+                eprintln!("Missing property: \"{}\"!", property);
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/blocks/compare/mod.rs
+++ b/src/blocks/compare/mod.rs
@@ -1,0 +1,20 @@
+use clap::Args;
+use crate::util::file::InputFile;
+
+#[derive(Args, Debug)]
+/// Compare two data versions one-directional
+///
+/// Currently only compares block data
+pub struct CompareCommand {
+    /// The intermediary data file to start from
+    base: InputFile,
+    /// The target intermediary data file to find compatibility with
+    target: InputFile,
+}
+
+impl CompareCommand {
+    pub fn compare(&self) -> anyhow::Result<()> {
+        eprintln!("Comparing...");
+        Ok(())
+    }
+}

--- a/src/blocks/compare/mod.rs
+++ b/src/blocks/compare/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::Args;
-use crate::blocks::compare::kinds::PropertyComparison;
+use crate::blocks::compare::kinds::{BlockComparison, PropertyComparison};
 use crate::blocks::intermediary::data::ModernBlockList;
 use crate::util::file::InputFile;
 
@@ -15,6 +15,9 @@ pub struct CompareCommand {
     base: InputFile,
     /// The target intermediary data file to find compatibility with
     target: InputFile,
+    /// Don't list missing entries
+    #[clap(long = "print-missing")]
+    print_missing: bool,
 }
 
 impl CompareCommand {
@@ -22,17 +25,49 @@ impl CompareCommand {
         let base_version: ModernBlockList = self.base.data().with_context(|| format!("Error deserializing {:?}", self.base.name()))?;
         let target_version: ModernBlockList = self.target.data().with_context(|| format!("Error deserializing {:?}", self.target.name()))?;
 
-        eprintln!("Checking property compatibility...");
+        eprintln!("Checking property compatibility...\n=============");
+        let mut missing_props = 0;
         for (property, base) in base_version.properties() {
             if let Some(target) = target_version.properties().get(property) {
                 match PropertyComparison::compare(base, target) {
                     PropertyComparison::Equal => {}
-                    cmp => eprintln!("\"{}\" has {:?}", property, cmp),
+                    cmp => println!("\"{}\" has {:?}", property, cmp),
                 }
             } else {
-                eprintln!("Missing property: \"{}\"!", property);
+                if self.print_missing {
+                    println!("Missing property: \"{}\"!", property);
+                }
+                missing_props += 1;
             }
         }
+        eprintln!("=============\nChecking block compatibility...\n=============");
+        let mut missing_count = 0;
+        let mut same_base = 0;
+        let mut perfect_count = 0;
+        for (name, data) in base_version.blocks() {
+            if let Some(target) = target_version.blocks().get(name) {
+                match BlockComparison::compare(data, target) {
+                    BlockComparison::Equal => {
+                        if data.base_id() == target.base_id() {
+                            perfect_count += 1;
+                        }
+                    }
+                    cmp => eprintln!("\"{}\" has \"{:?}\"", name, cmp),
+                }
+                if data.base_id() == target.base_id() {
+                    same_base += 1;
+                }
+            } else {
+                if self.print_missing {
+                    println!("Missing blocks: \"{}\"", name);
+                }
+                missing_count += 1;
+            }
+        }
+        println!("=============\nMissing {} properties", missing_props);
+        println!("Missing {} blocks", missing_count);
+        println!("{} out of {} have the same base id", same_base, base_version.blocks().len() - missing_count);
+        println!("{} perfect blocks", perfect_count);
 
         Ok(())
     }

--- a/src/blocks/intermediary/data.rs
+++ b/src/blocks/intermediary/data.rs
@@ -25,6 +25,10 @@ impl<'raw> ModernBlockList<'raw> {
     pub fn properties(&self) -> &LinkedHashMap<&'raw str, Vec<&'raw str>> {
         &self.properties
     }
+
+    pub fn blocks(&self) -> &LinkedHashMap<Identifier<'raw>, ModernBlockData<'raw>, RandomState> {
+        &self.blocks
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -45,6 +49,14 @@ impl<'raw> ModernBlockData<'raw> {
             default_id
         }
     }
+
+    pub fn properties(&self) -> Option<&LinkedHashMap<&'raw str, TextOrRange<'raw>, RandomState>> {
+        self.kinds.as_ref()
+    }
+
+    pub fn base_id(&self) -> i32 {
+        self.base_id
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -62,5 +74,44 @@ impl<'raw> TextOrRange<'raw> {
     
     pub fn range(start: i32, end: i32) -> Self {
         Self::Range([start, end])
+    }
+
+    pub fn is_bool(&self) -> bool {
+        matches!(self, TextOrRange::Text(val) if val == &"bool")
+    }
+
+    pub fn is_enum(&self) -> bool {
+        matches!(self, TextOrRange::Text(val) if val != &"bool")
+    }
+
+    pub fn is_range(&self) -> bool {
+        matches!(self, TextOrRange::Range(_))
+    }
+
+    pub fn get_enum(&self) -> Option<&'raw str> {
+        match self {
+            TextOrRange::Text(val) if val != &"bool" => {
+                Some(val)
+            }
+            _ => None
+        }
+    }
+}
+
+impl<'raw> PartialEq for TextOrRange<'raw> {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            TextOrRange::Text(val) => {
+                if let Self::Text(other) = other {
+                    return val == other;
+                }
+            }
+            TextOrRange::Range(range) => {
+                if let Self::Range(other) = other {
+                    return range == other;
+                }
+            }
+        }
+        false
     }
 }

--- a/src/blocks/intermediary/data.rs
+++ b/src/blocks/intermediary/data.rs
@@ -21,6 +21,10 @@ impl<'raw> ModernBlockList<'raw> {
             blocks,
         }
     }
+
+    pub fn properties(&self) -> &LinkedHashMap<&'raw str, Vec<&'raw str>> {
+        &self.properties
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -1,2 +1,3 @@
+pub mod compare;
 pub mod intermediary;
 pub mod raw;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use blocks::intermediary::IntermediaryCommand;
+use blocks::compare::CompareCommand;
 
 mod blocks;
 mod util;
@@ -14,6 +15,7 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum SubCommands {
+    Compare(CompareCommand),
     Intermediary(IntermediaryCommand),
 }
 
@@ -23,6 +25,9 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         SubCommands::Intermediary(cmd) => {
             cmd.generate_intermediate().with_context(|| "Error while generating data")
+        }
+        SubCommands::Compare(cmd) => {
+            cmd.compare().with_context(|| "Error while comparing data")
         }
     }
 }


### PR DESCRIPTION
This subcommand should be able to compare two data versions (block data for now).

A few requirements:
- [x] one directional comparison (i.e. *from* a version *to* another version)
- [ ] easy to read summary of the incompatibilities
- [ ] interactive menu for specifying compatibility fixes (although I think it's better if that was done in a different pr, feels like a separate topic to me)

First gonna figure out the ways block data can cause incompatibilities and list these here as well.